### PR TITLE
Multiplier selection

### DIFF
--- a/src/main/java/alrapal/App.java
+++ b/src/main/java/alrapal/App.java
@@ -29,9 +29,11 @@ public class App extends Application {
         mainWindow.setResizable(false);
 
         mainWindow.setOnCloseRequest(event -> {
-            ImportExportClass export = controller.getImportExportClass();
-            float baseDamage = controller.getSynchro().getBaseDamage();
-            export.exportConfig(baseDamage);
+            if (controller.getImportedBase() != controller.getSynchro().getBaseDamage()) {
+                ImportExportClass export = controller.getImportExportClass();
+                float baseDamage = controller.getSynchro().getBaseDamage();
+                export.exportConfig(baseDamage);
+            }
             Platform.exit();
         });
     }

--- a/src/main/java/alrapal/ImportExport/ImportExportClass.java
+++ b/src/main/java/alrapal/ImportExport/ImportExportClass.java
@@ -52,14 +52,14 @@ public class ImportExportClass {
         }
     }
 
-    public void importConfig(TextField baseDamageInput, Label infoLabel){
+    public float importConfig(TextField baseDamageInput, Label infoLabel){
+        float importedBase_ = 0;
         File baseFile = new File(filePathBaseSynchro);
         try(Scanner scanner = new Scanner(baseFile)) {
             String importedBase = scanner.nextLine();
-            float importedBase_ = Float.parseFloat(importedBase);
+            importedBase_ = Float.parseFloat(importedBase);
             if (importedBase_ == 368){
                 infoLabel.setText("INFO: Utilisation de la base de dommage correspondant au niveau 200");
-                return;
             }else {
                 baseDamageInput.setText(importedBase);
                 //synchro.setBaseDamage(newBase);
@@ -68,6 +68,8 @@ public class ImportExportClass {
         } catch (FileNotFoundException e) {
             infoLabel.setText("INFO: Utilisation de la base de dommage correspondant au niveau 200");
         }
+        if (importedBase_ == 0){
+        return 368;}else{ return importedBase_;}
     }
 
 }

--- a/src/main/java/alrapal/MainWindowController.java
+++ b/src/main/java/alrapal/MainWindowController.java
@@ -7,6 +7,7 @@ import alrapal.Objects.Multiplier;
 import alrapal.Objects.ShieldAndEpic;
 import alrapal.Objects.Synchro;
 import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableBooleanValue;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -14,8 +15,10 @@ import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.Parent;
 import javafx.scene.control.*;
+import javafx.scene.control.cell.CheckBoxListCell;
 import javafx.scene.input.MouseEvent;
 import javafx.stage.Stage;
+import javafx.util.Callback;
 import org.controlsfx.control.textfield.CustomTextField;
 import org.controlsfx.control.textfield.TextFields;
 import java.util.ArrayList;
@@ -109,6 +112,8 @@ public class MainWindowController {
         });
 
         damageMultiplierOutput.setItems(registeredMultiplier);
+
+        damageMultiplierOutput.setCellFactory(CheckBoxListCell.forListView(Multiplier::activatedProperty));
 
 
     }

--- a/src/main/java/alrapal/Objects/Enemy.java
+++ b/src/main/java/alrapal/Objects/Enemy.java
@@ -42,7 +42,11 @@ public class Enemy {
     ////////////////////////////////////////////////////////////////////////////////////
 
     public void addMultiplier(float newMultiplier){
-        this.damageMultiplier = this.damageMultiplier *newMultiplier;
+        this.damageMultiplier = this.damageMultiplier * (newMultiplier/100);
+    }
+
+    public void removeMultiplier(float multiplier){
+        this.damageMultiplier = this.damageMultiplier / (multiplier/100);
     }
 
     public float getTotalRangedMultiplierMin(){

--- a/src/main/java/alrapal/Objects/Multiplier.java
+++ b/src/main/java/alrapal/Objects/Multiplier.java
@@ -1,31 +1,41 @@
 package alrapal.Objects;
 
-public class Multiplier {
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
+
+public class Multiplier  {
 
     /** Attributes */
     private String name;
     private float value;
-    private boolean activated;
+    private BooleanProperty activated;
 
     /** Constructor */
     public Multiplier(String name, float value){
         this.name = name;
         this.value = value;
-        this.activated = true;
+        this.activated = new SimpleBooleanProperty(true);
     }
 
     /** Getters **/
     public String getName(){return this.name;}
     public float getValue(){return this.value;}
-    public boolean isActivated(){return this.activated;}
+    public BooleanProperty activatedProperty() {return this.activated;}
 
     /** Setters */
     public void setName(String name){this.name = name;}
     public void setValue(float value){this.value = value;}
-    public void setActivated(Boolean activated){this.activated = activated;}
+
 
     /** Methods */
     public String toString(){
-        return name + " <> " + value + "%";
+        DecimalFormatSymbols symbols = new DecimalFormatSymbols(Locale.FRANCE);
+        DecimalFormat decimalFormat = new DecimalFormat("#.#", symbols);
+        return name + " <> " + decimalFormat.format(value) + "%";
     }
+
 }

--- a/src/main/java/alrapal/Objects/Multiplier.java
+++ b/src/main/java/alrapal/Objects/Multiplier.java
@@ -1,0 +1,31 @@
+package alrapal.Objects;
+
+public class Multiplier {
+
+    /** Attributes */
+    private String name;
+    private float value;
+    private boolean activated;
+
+    /** Constructor */
+    public Multiplier(String name, float value){
+        this.name = name;
+        this.value = value;
+        this.activated = true;
+    }
+
+    /** Getters **/
+    public String getName(){return this.name;}
+    public float getValue(){return this.value;}
+    public boolean isActivated(){return this.activated;}
+
+    /** Setters */
+    public void setName(String name){this.name = name;}
+    public void setValue(float value){this.value = value;}
+    public void setActivated(Boolean activated){this.activated = activated;}
+
+    /** Methods */
+    public String toString(){
+        return name + " <> " + value + "%";
+    }
+}


### PR DESCRIPTION
- Les multiplicateurs de dommages subits ont une checkbox qui permet de les activer / désactiver lors du calcul.
- L'écriture du fichier .txt sauvegardant la dernière base de dommage de la Synchro ne s'effectue que lorsque la dernière base utilisée est différente de celle importée lors de l'ouverture du calculateur